### PR TITLE
add basic travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: rust
+rust:
+  - stable
+before_install:
+  - sudo apt-get install -y libsfml-dev libcsfml-dev
+script:
+  - ( cd worldgen && cargo build )
+  - ( cd worldsim && cargo build )
+  - ( cd worldtest && cargo build )
+  - ( cd server && cargo build )
+  - ( cd frontend && cargo build )
+  - ( cd client && cargo build )
+  - ./frontend/target/debug/frontend


### PR DESCRIPTION
this is a basic travis.yml which will trigger compilation under ubuntu, and will the  ./worldtest/target/debug/worldsim testfile
You can see this run under: https://travis-ci.com/xMAC94x/game/jobs/126515079
As soon as travis-CI is enabled for veloren project it should automaticly build all new pushes and merges