### PR TITLE
Autodetect local UDP port

### DIFF
--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -7,4 +7,5 @@ authors = ["Terah <terah.dev@gmail.com>"]
 bincode = "1.0.0"
 serde = "1.0.63"
 serde_derive = "1.0.63"
+get_if_addrs = "0.5.2"
 nalgebra = { version= "0.15.1", features = ["serde-serialize"] }

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -4,6 +4,7 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate bincode;
+extern crate get_if_addrs;
 extern crate nalgebra;
 
 pub mod packet;

--- a/voxygen/src/main.rs
+++ b/voxygen/src/main.rs
@@ -31,16 +31,10 @@ use game::Game;
 fn main() {
     println!("Starting Voxygen...");
 
-    // TODO: Seriously? This needs to go. Make it auto-detect this stuff
-    // <rubbish>
     let ip = get_if_addrs::get_if_addrs().unwrap()[0].ip();
+    let port: u16 = 59001;
 
-    let mut port = String::new();
-    println!("Local port [59001]:");
-    io::stdin().read_line(&mut port).unwrap();
-    let port = u16::from_str_radix(&port.trim(), 10).unwrap_or(59001);
-
-    println!("Binding to {}:{}...", ip.to_string(), port);
+    println!("Binding local port to {}:{}...", ip.to_string(), port);
 
     let mut remote_addr = String::new();
     println!("Remote server address [127.0.0.1:59003]:");
@@ -49,7 +43,6 @@ fn main() {
     if remote_addr.len() == 0 {
         remote_addr = "127.0.0.1:59003".to_string();
     }
-    // </rubbish>
 
     let game = Game::new(
         ClientMode::Character,


### PR DESCRIPTION
Client no longer asks for a UDP port, instead searches for the first open from 59001.