### PR TITLE
Added simple argument for voxygen boot (and some other clarifications)

### DIFF
--- a/voxygen/src/main.rs
+++ b/voxygen/src/main.rs
@@ -31,7 +31,7 @@ mod key_state;
 mod map;
 mod vox;
 
-use std::io;
+use std::io::{self, Write};
 
 use client::ClientMode;
 use game::Game;
@@ -43,14 +43,29 @@ fn main() {
     info!("Starting Voxygen... Version: {}", get_version());
 
     let mut remote_addr = String::new();
-    println!("Remote server address [127.0.0.1:59003] (use m for testserver):");
-    io::stdin().read_line(&mut remote_addr).unwrap();
+    println!("Remote server address [Default: 127.0.0.1:59003] (use m for testserver):");
+
+    let mut args = std::env::args();
+
+    // expects single command line argument that is the remote_addr
+    if args.len() == 2 {
+        remote_addr = args.nth(1).expect("No argument");
+    }
+        else {
+            // If args aren't correct then read from stdin
+            print!("Enter address (blank for default): ");
+            io::stdout().flush().expect("Failed to flush");
+            io::stdin().read_line(&mut remote_addr).unwrap();
+        }
+
     let mut remote_addr = remote_addr.trim();
     if remote_addr.len() == 0 {
         remote_addr = "127.0.0.1:59003";
     } else if remote_addr == "m" {
         remote_addr = "91.67.21.222:38888";
     }
+
+    println!("Connecting to {}", remote_addr);
 
     Game::new(
         ClientMode::Character,

--- a/voxygen/src/main.rs
+++ b/voxygen/src/main.rs
@@ -51,12 +51,12 @@ fn main() {
     if args.len() == 2 {
         remote_addr = args.nth(1).expect("No argument");
     }
-        else {
-            // If args aren't correct then read from stdin
-            print!("Enter address (blank for default): ");
-            io::stdout().flush().expect("Failed to flush");
-            io::stdin().read_line(&mut remote_addr).unwrap();
-        }
+    else {
+        // If args aren't correct then read from stdin
+        print!("Enter address (blank for default): ");
+        io::stdout().flush().expect("Failed to flush");
+        io::stdin().read_line(&mut remote_addr).unwrap();
+    }
 
     let mut remote_addr = remote_addr.trim();
     if remote_addr.len() == 0 {


### PR DESCRIPTION
Hi, back again with a (hopefully) helpful little addition for dev purposes.

Voxygen can now (optionally) take an argument for the remote addr. Like `voxygen <addr>`. You can just pass in "" for this if you want to connect to the local or just "m" for the test server. Otherwise if the argument is missing it just behaves as before.

Since it's a little confusing at first as to what's going on when you boot up voxygen for the first time I changed the wording a bit to hopefully clarify for newcomers.